### PR TITLE
feat: add directional amounts

### DIFF
--- a/boltz_client/boltz.py
+++ b/boltz_client/boltz.py
@@ -2,8 +2,8 @@
 
 import asyncio
 from dataclasses import dataclass
-from typing import Optional
 from math import ceil, floor
+from typing import Optional
 
 import httpx
 
@@ -142,7 +142,6 @@ class BoltzClient:
         mempool_fees = feerate if feerate else self.mempool.get_fees()
         return mempool_fees * tx_size_vbyte
 
-
     def setup_boltz_config(self) -> None:
         data = self.request(
             "get",
@@ -240,7 +239,9 @@ class BoltzClient:
             privkey_wif=privkey_wif,
             redeem_script_hex=redeem_script_hex,
             preimage_hex=preimage_hex,
-            fees=self.get_fee_estimation(feerate) if feerate else self.get_fee_estimation_claim(),
+            fees=self.get_fee_estimation(feerate)
+            if feerate
+            else self.get_fee_estimation_claim(),
         )
         self.mempool.send_onchain_tx(transaction)
         return txid
@@ -265,7 +266,9 @@ class BoltzClient:
             receive_address=receive_address,
             redeem_script_hex=redeem_script_hex,
             timeout_block_height=timeout_block_height,
-            fees=self.get_fee_estimation(feerate) if feerate else self.get_fee_estimation_refund(),
+            fees=self.get_fee_estimation(feerate)
+            if feerate
+            else self.get_fee_estimation_refund(),
         )
         self.mempool.send_onchain_tx(transaction)
         return txid

--- a/boltz_client/boltz.py
+++ b/boltz_client/boltz.py
@@ -3,6 +3,7 @@
 import asyncio
 from dataclasses import dataclass
 from typing import Optional
+from math import ceil, floor
 
 import httpx
 
@@ -95,8 +96,7 @@ class BoltzClient:
         self._cfg = config
         self.limit_minimal = 0
         self.limit_maximal = 0
-        self.fee_percentage = 0
-        self.set_limits()
+        self.setup_boltz_config()
         self.mempool = MempoolClient(self._cfg.mempool_url, self._cfg.mempool_ws_url)
 
     def request(self, funcname, *args, **kwargs) -> dict:
@@ -118,6 +118,23 @@ class BoltzClient:
             headers={"Content-Type": "application/json"},
         )
 
+    def add_reverse_swap_fees(self, amount: int) -> int:
+        rev = self.fees["minerFees"]["baseAsset"]["reverse"]
+        fee = rev["claim"] + rev["lockup"]
+        percent = self.fees["percentage"]
+        return ceil((amount + fee) / (1 - (percent / 100)))
+
+    def substract_swap_fees(self, amount: int) -> int:
+        fee = self.fees["minerFees"]["baseAsset"]["normal"]
+        percent = self.fees["percentageSwapIn"]
+        return floor((amount - fee) / (1 + (percent / 100)))
+
+    def get_fee_estimation_claim(self) -> int:
+        return self.fees["minerFees"]["baseAsset"]["reverse"]["claim"]
+
+    def get_fee_estimation_refund(self) -> int:
+        return self.fees["minerFees"]["baseAsset"]["normal"]
+
     def get_fee_estimation(self, feerate: Optional[int]) -> int:
         # TODO: hardcoded maximum tx size, in the future we try to get the size of the
         # tx via embit we need a function like Transaction.vsize()
@@ -125,18 +142,18 @@ class BoltzClient:
         mempool_fees = feerate if feerate else self.mempool.get_fees()
         return mempool_fees * tx_size_vbyte
 
-    def set_limits(self) -> None:
+
+    def setup_boltz_config(self) -> None:
         data = self.request(
             "get",
             f"{self._cfg.api_url}/getpairs",
             headers={"Content-Type": "application/json"},
         )
         pair = data["pairs"]["BTC/BTC"]
+        self.fees = pair["fees"]
         limits = pair["limits"]
-        fees = pair["fees"]
         self.limit_maximal = limits["maximal"]
         self.limit_minimal = limits["minimal"]
-        self.fee_percentage = fees["percentage"]
 
     def check_limits(self, amount: int) -> None:
         valid = self.limit_minimal <= amount <= self.limit_maximal
@@ -223,7 +240,7 @@ class BoltzClient:
             privkey_wif=privkey_wif,
             redeem_script_hex=redeem_script_hex,
             preimage_hex=preimage_hex,
-            fees=self.get_fee_estimation(feerate),
+            fees=self.get_fee_estimation(feerate) if feerate else self.get_fee_estimation_claim(),
         )
         self.mempool.send_onchain_tx(transaction)
         return txid
@@ -248,9 +265,8 @@ class BoltzClient:
             receive_address=receive_address,
             redeem_script_hex=redeem_script_hex,
             timeout_block_height=timeout_block_height,
-            fees=self.get_fee_estimation(feerate),
+            fees=self.get_fee_estimation(feerate) if feerate else self.get_fee_estimation_refund(),
         )
-
         self.mempool.send_onchain_tx(transaction)
         return txid
 

--- a/boltz_client/cli.py
+++ b/boltz_client/cli.py
@@ -98,11 +98,21 @@ def refund_swap(
 
 @click.command()
 @click.argument("sats", type=int)
-def create_reverse_swap(sats: int):
+@click.argument("direction", type=str, default="send")
+def create_reverse_swap(sats: int, direction: str):
     """
     create a reverse swap
     """
     client = BoltzClient(config)
+
+    if direction == "receive":
+        sats = client.add_reverse_swap_fees(sats)
+    elif direction == "send":
+        # dont do anythin on reverse swap
+        pass
+    else:
+        raise ValueError("direction must be 'send' or 'receive'")
+
     claim_privkey_wif, preimage_hex, swap = client.create_reverse_swap(sats)
 
     click.echo("reverse swap created!")
@@ -131,13 +141,23 @@ def create_reverse_swap(sats: int):
 @click.argument("receive_address", type=str)
 @click.argument("sats", type=int)
 @click.argument("zeroconf", type=bool, default=False)
+@click.argument("direction", type=str, default="send")
 def create_reverse_swap_and_claim(
-    receive_address: str, sats: int, zeroconf: bool = False
+    receive_address: str, sats: int, zeroconf: bool = False, direction: str = "send"
 ):
     """
     create a reverse swap and claim
     """
     client = BoltzClient(config)
+
+    if direction == "receive":
+        sats = client.add_reverse_swap_fees(sats)
+    elif direction == "send":
+        # dont do anythin on reverse swap
+        pass
+    else:
+        raise ValueError("direction must be 'send' or 'receive'")
+
     claim_privkey_wif, preimage_hex, swap = client.create_reverse_swap(sats)
 
     click.echo("reverse swap created!")
@@ -226,6 +246,17 @@ def swap_status(swap_id):
     click.echo(data)
 
 
+@click.command()
+@click.argument("amount", type=int)
+def calculate_swap_send_amount(amount):
+    """
+    calculate the amount of the invoice you have to send to boltz
+    to send the specified amount onchain
+    """
+    client = BoltzClient(config)
+    click.echo(client.substract_swap_fees(amount))
+
+
 def main():
     """main function"""
     command_group.add_command(swap_status)
@@ -234,6 +265,7 @@ def main():
     command_group.add_command(create_reverse_swap)
     command_group.add_command(create_reverse_swap_and_claim)
     command_group.add_command(claim_reverse_swap)
+    command_group.add_command(calculate_swap_send_amount)
     command_group()
 
 

--- a/tests/test_boltz_lifecycle_reverse_swap.py
+++ b/tests/test_boltz_lifecycle_reverse_swap.py
@@ -10,6 +10,7 @@ from boltz_client.boltz import (
 
 from .helpers import create_onchain_address, mine_blocks, pay_invoice
 
+
 @pytest.mark.asyncio
 async def test_create_reverse_swap_and_claim(client: BoltzClient):
     claim_privkey_wif, preimage_hex, swap = client.create_reverse_swap(10000)

--- a/tests/test_boltz_lifecycle_swap.py
+++ b/tests/test_boltz_lifecycle_swap.py
@@ -10,7 +10,16 @@ from boltz_client.boltz import (
 )
 from boltz_client.mempool import MempoolBlockHeightException
 
-from .helpers import create_onchain_address, mine_blocks, pay_onchain
+from .helpers import create_onchain_address, mine_blocks, pay_onchain, get_invoice
+
+
+@pytest.mark.asyncio
+async def test_create_swap_direction(client):
+    amount = 110000
+    swap_amount = client.substract_swap_fees(amount)
+    invoice = get_invoice(swap_amount, "direction-test")
+    _, swap = client.create_swap(invoice["bolt11"])
+    assert swap.expectedAmount == amount
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
lets you specfify a direction for reverse swaps, 'receive' mean you will receive the amount specified
- add cli command to calculate invoice amount to be able to send a specific onchain amount
- tests for both lifecycles

closes lnbits/boltz/issues/16